### PR TITLE
Add player utils tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.2",
@@ -26,6 +27,9 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.3.2",
+    "@types/jest": "^29.5.5"
   }
 }

--- a/src/utils/playerUtils.test.ts
+++ b/src/utils/playerUtils.test.ts
@@ -1,0 +1,73 @@
+import { startGame } from './playerUtils';
+
+type Player = { name: string; isSpy: boolean; role: string };
+
+const createPlayers = (count: number): Player[] =>
+  Array.from({ length: count }, (_, i) => ({ name: `Player${i}`, isSpy: false, role: '' }));
+
+let store: Record<string, string>;
+
+beforeEach(() => {
+  store = {};
+  Object.defineProperty(global, 'localStorage', {
+    value: {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      }
+    },
+    configurable: true
+  });
+  jest.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('startGame', () => {
+  test('sets the correct number of spies', () => {
+    const players = createPlayers(5);
+    startGame(players, 2);
+    const storedPlayers = JSON.parse(localStorage.getItem('players')!);
+    const spyCount = storedPlayers.filter((p: Player) => p.isSpy).length;
+    expect(spyCount).toBe(2);
+  });
+
+  test('assigns unique and random roles to non-spies', () => {
+    const players = createPlayers(6);
+
+    const firstSeq = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9];
+    let index = 0;
+    const randomSpy = jest.spyOn(Math, 'random').mockImplementation(() => firstSeq[index++ % firstSeq.length]);
+
+    startGame(players, 2);
+    const firstRun = JSON.parse(localStorage.getItem('players')!);
+    const firstRoles = firstRun.filter((p: Player) => !p.isSpy).map((p: Player) => p.role);
+    expect(new Set(firstRoles).size).toBe(firstRoles.length);
+
+    localStorage.clear();
+    index = 0;
+    randomSpy.mockImplementation(() => firstSeq.reverse()[index++ % firstSeq.length]);
+
+    startGame(players, 2);
+    const secondRun = JSON.parse(localStorage.getItem('players')!);
+    const secondRoles = secondRun.filter((p: Player) => !p.isSpy).map((p: Player) => p.role);
+    expect(new Set(secondRoles).size).toBe(secondRoles.length);
+    expect(secondRoles).not.toEqual(firstRoles);
+  });
+
+  test('saves game data to localStorage', () => {
+    const players = createPlayers(4);
+    startGame(players, 1);
+    expect(localStorage.getItem('location')).not.toBeNull();
+    expect(localStorage.getItem('players')).not.toBeNull();
+    expect(localStorage.getItem('selectedLocation')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest using ts-jest
- add tests for spy assignment, role distribution, and localStorage

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fc62432c83328987b7519b1df42f