### PR TITLE
Improve SEO metadata and lazy load mascot

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
-import type { Metadata } from "next";
-import { Prompt  } from "next/font/google";
+import type { Metadata, Viewport } from "next";
+import { Prompt } from "next/font/google";
 import "./globals.css";
 
 const prompt = Prompt({
@@ -12,7 +12,26 @@ const prompt = Prompt({
 
 export const metadata: Metadata = {
   title: "Spy Game",
-  description: "",
+  description: "A party game of deduction and deception.",
+  keywords: ["spy game", "party game", "deduction", "multiplayer"],
+  robots: { index: true, follow: true },
+  openGraph: {
+    title: "Spy Game",
+    description: "Join your friends to uncover the spy!",
+    type: "website",
+    locale: "en_US",
+    siteName: "Spy Game",
+  },
+  twitter: {
+    card: "summary",
+    title: "Spy Game",
+    description: "Join your friends to uncover the spy!",
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,11 @@ import {
   isReadyToStart
 } from "../utils/playerUtils";
 import { motion } from "framer-motion";
-import KawaiiMascot from "./components/KawaiiMascot";
+import dynamic from "next/dynamic";
+
+const KawaiiMascot = dynamic(() => import("./components/KawaiiMascot"), {
+  ssr: false,
+});
 
 export default function Home() {
   const [players, setPlayers] = useState([


### PR DESCRIPTION
## Summary
- enhance site metadata for better SEO and social sharing
- lazily load KawaiiMascot component to reduce initial bundle size

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a609a88ecc8332b08ac29c1d374e62