### PR TITLE
feat: redesign with minimal spy ui

### DIFF
--- a/src/app/agents/page.tsx
+++ b/src/app/agents/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import BottomNav from "../components/BottomNav";
+
+const agents = [
+  { name: "Luna", rarity: "common" },
+  { name: "Milo", rarity: "rare" },
+  { name: "Nova", rarity: "epic" },
+];
+
+const colors: Record<string, string> = {
+  common: "bg-gray-300",
+  rare: "bg-pink-300",
+  epic: "bg-purple-300",
+};
+
+export default function AgentsPage() {
+  return (
+    <div className="min-h-screen pb-16 bg-gray-50 p-4 text-gray-800">
+      <h1 className="text-xl mb-4">Agents</h1>
+      <div className="grid gap-4">
+        {agents.map((a) => (
+          <div key={a.name} className="bg-white rounded-xl p-4 shadow">
+            <div className="flex items-center justify-between">
+              <span>{a.name}</span>
+              <span className={`w-3 h-3 rounded-full ${colors[a.rarity]}`}></span>
+            </div>
+          </div>
+        ))}
+      </div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/components/BottomNav.tsx
+++ b/src/app/components/BottomNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Play, Users, Inbox, ShoppingBag, Settings as Cog } from "lucide-react";
+
+const tabs = [
+  { href: "/", icon: Play, label: "Play" },
+  { href: "/agents", icon: Users, label: "Agents" },
+  { href: "/inbox", icon: Inbox, label: "Inbox" },
+  { href: "/shop", icon: ShoppingBag, label: "Shop" },
+  { href: "/settings", icon: Cog, label: "Settings" },
+];
+
+export default function BottomNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200">
+      <ul className="flex justify-between">
+        {tabs.map(({ href, icon: Icon, label }) => {
+          const active = pathname === href;
+          return (
+            <li key={href} className="flex-1">
+              <Link
+                href={href}
+                className="flex flex-col items-center py-2 text-xs"
+                aria-label={label}
+              >
+                <Icon
+                  className={`h-5 w-5 ${active ? "text-pink-500" : "text-gray-400"}`}
+                />
+                <span className={active ? "text-pink-500" : "text-gray-400"}>
+                  {label}
+                </span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/src/app/components/ProgressBar.tsx
+++ b/src/app/components/ProgressBar.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+interface Props {
+  value: number; // 0-100
+}
+
+export default function ProgressBar({ value }: Props) {
+  return (
+    <div className="w-full bg-gray-200 h-1">
+      <div
+        className="h-full bg-pink-500 transition-all duration-200"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  );
+}

--- a/src/app/components/Toast.tsx
+++ b/src/app/components/Toast.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface Props {
+  message: string;
+  show: boolean;
+  onClose: () => void;
+}
+
+export default function Toast({ message, show, onClose }: Props) {
+  useEffect(() => {
+    if (show) {
+      const timer = setTimeout(onClose, 2500);
+      return () => clearTimeout(timer);
+    }
+  }, [show, onClose]);
+
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.2, ease: "easeOut" }}
+          className="fixed top-4 right-4 bg-white shadow px-4 py-2 rounded-lg text-gray-800"
+        >
+          {message}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,25 +6,20 @@
 }
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --neutral: #ffffff;
+  --neutral-2: #f4f4f5;
+  --accent: #ff6b9a;
+  --text: #222222;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: var(--neutral);
+  --color-foreground: var(--text);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
-  color: var(--foreground);
+  background: var(--neutral);
+  color: var(--text);
 }

--- a/src/app/inbox/page.tsx
+++ b/src/app/inbox/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import BottomNav from "../components/BottomNav";
+
+const messages = ["Meet at dawn", "Code red", "Report in"];
+
+export default function InboxPage() {
+  return (
+    <div className="min-h-screen pb-16 bg-gray-50 p-4 text-gray-800">
+      <h1 className="text-xl mb-4">Inbox</h1>
+      <ul className="space-y-2">
+        {messages.map((m, i) => (
+          <li key={i} className="bg-white p-4 rounded-xl shadow">
+            {m}
+          </li>
+        ))}
+      </ul>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const steps = ["Welcome Agent", "Trust no one", "Earn XP"];
+
+export default function OnboardingPage() {
+  const [step, setStep] = useState(0);
+  const router = useRouter();
+
+  const next = () => {
+    if (step < steps.length - 1) setStep(step + 1);
+    else router.push("/");
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-gray-50 text-center text-gray-800">
+      <p className="mb-8 text-lg">{steps[step]}</p>
+      <button
+        onClick={next}
+        className="w-full max-w-xs h-12 bg-pink-500 text-white rounded-lg mb-4"
+      >
+        Next
+      </button>
+      <button
+        onClick={() => router.push("/")}
+        className="text-gray-500 text-sm"
+      >
+        Skip
+      </button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,185 +1,50 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import {
-  handlePlayerChange,
-  addPlayer,
-  removePlayer,
-  startGame,
-  isReadyToStart
-} from "../utils/playerUtils";
-import { motion } from "framer-motion";
-import dynamic from "next/dynamic";
+import ProgressBar from "./components/ProgressBar";
+import Toast from "./components/Toast";
+import BottomNav from "./components/BottomNav";
 
-const KawaiiMascot = dynamic(() => import("./components/KawaiiMascot"), {
-  ssr: false,
-});
+const missions = ["Retrieve docs", "Crack code", "Hide evidence"];
 
-export default function Home() {
-  const [players, setPlayers] = useState([
-    { name: "", isSpy: false, role: "" },
-    { name: "", isSpy: false, role: "" },
-    { name: "", isSpy: false, role: "" }
-  ]);
-  const [spyNum, setSpyNum] = useState<number>(1);
-  const [timeLimit, setTimeLimit] = useState<number>(5);
+export default function PlayPage() {
+  const [step, setStep] = useState(0);
+  const [toast, setToast] = useState("");
   const router = useRouter();
 
-  const isReadyToStartCheck = isReadyToStart(players);
-
-  const handleStartGame = () => {
-    if (isReadyToStartCheck) {
-      startGame(players, spyNum);
-      localStorage.setItem("timeLimit", timeLimit.toString());
-      router.push("/game");
-    }
+  const handleAction = () => {
+    const success = Math.random() > 0.5;
+    setToast(success ? "+5 XP" : "+0 XP");
+    const next = (step + 1) % missions.length;
+    setStep(next);
+    setTimeout(() => {
+      router.push(`/result?success=${success}`);
+    }, 2500);
   };
 
-  useEffect(() => {
-    const playersData = JSON.parse(localStorage.getItem("players") || "[]");
-    if (playersData?.length > 0) {
-      setPlayers(playersData);
-    }
-  }, []);
-
   return (
-    <div className="min-h-screen p-6 sm:p-12 bg-gradient-to-br from-gray-900 to-gray-800 text-white font-sans">
-      <motion.header
-        initial={{ opacity: 0, y: -30 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-        className="text-center mb-12"
-      >
-        <h1 className="text-5xl font-extrabold bg-gradient-to-r from-green-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">
-          Spy Game 🎮
-        </h1>
-        <p className="text-lg text-gray-300 mt-3">
-          ค้นหาสายลับ ทำภารกิจให้สำเร็จ อย่าไว้ใจใครง่าย ๆ
-        </p>
-      </motion.header>
-
-      <main className="max-w-3xl mx-auto space-y-10">
-        {/* ผู้เล่น */}
-        <motion.section
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.1 }}
-          className="bg-gray-800 p-6 rounded-2xl shadow-lg"
-        >
-          <h2 className="text-2xl font-semibold text-green-300 mb-4">
-            จำนวนผู้เล่น
-          </h2>
-
-          {players.map((player, index) => (
-            <div key={index} className="flex items-center gap-2 mb-3">
-              <input
-                type="text"
-                placeholder={`ผู้เล่นคนที่ ${index + 1}`}
-                value={player.name}
-                onChange={(e) =>
-                  handlePlayerChange(players, index, e.target.value, setPlayers)
-                }
-                className="flex-1 p-2 rounded-lg bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-blue-400 transition"
-              />
-              {players.length > 3 && (
-                <button
-                  onClick={() => removePlayer(players, index, setPlayers)}
-                  className="bg-red-500 hover:bg-red-600 p-2 rounded-lg transition"
-                >
-                  -
-                </button>
-              )}
-            </div>
-          ))}
-
-          {players.length < 10 && (
+    <div className="min-h-screen pb-16 bg-gray-50 flex flex-col text-gray-800">
+      <ProgressBar value={(step / missions.length) * 100} />
+      <div className="flex-1 flex flex-col items-center justify-center p-4">
+        <div className="bg-white rounded-xl shadow p-6 text-center w-full max-w-xs">
+          <h2 className="text-lg mb-2">{missions[step]}</h2>
+          <p className="text-sm text-gray-500">Choose wisely</p>
+        </div>
+        <div className="mt-6 w-full max-w-xs space-y-3">
+          {"spy decode hide".split(" ").map((label) => (
             <button
-              onClick={() => addPlayer(players, setPlayers)}
-              className="w-full bg-blue-500 hover:bg-blue-600 p-2 mt-4 rounded-lg transition"
+              key={label}
+              className="w-full h-12 rounded-lg bg-pink-500 text-white"
+              onClick={handleAction}
             >
-              + เพิ่มผู้เล่น
+              {label[0].toUpperCase() + label.slice(1)}
             </button>
-          )}
-        </motion.section>
-
-        {/* เลือกจำนวนสายลับ */}
-        <motion.section
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.2 }}
-          className="bg-gray-800 p-6 rounded-2xl shadow-lg"
-        >
-          <h2 className="text-2xl font-semibold text-green-300 mb-4">
-            จำนวน SPY
-          </h2>
-          <div className="flex gap-4">
-            {[1, 2].map((num) => (
-              <label
-                key={num}
-                className="flex items-center gap-2 cursor-pointer text-white"
-              >
-                <input
-                  type="radio"
-                  name="spyNum"
-                  value={num}
-                  checked={spyNum === num}
-                  onChange={() => setSpyNum(num)}
-                  className="accent-green-400"
-                />
-                <span>{num} Spy</span>
-              </label>
-            ))}
-          </div>
-        </motion.section>
-
-        {/* ตั้งเวลาเล่นเกม */}
-        <motion.section
-          initial={{ opacity: 0, scale: 0.95 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ delay: 0.3 }}
-          className="bg-gray-800 p-6 rounded-2xl shadow-lg"
-        >
-          <h2 className="text-2xl font-semibold text-green-300 mb-4">
-            กำหนดเวลาเล่น
-          </h2>
-          <div className="flex items-center gap-4">
-            <input
-              type="number"
-              min={1}
-              value={timeLimit}
-              onChange={(e) => setTimeLimit(parseInt(e.target.value))}
-              className="w-24 p-2 rounded bg-gray-700 text-white focus:outline-none focus:ring-2 focus:ring-green-400 transition"
-            />
-            <span className="text-gray-300">นาที</span>
-          </div>
-        </motion.section>
-
-        {/* ปุ่มเริ่มเกม */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.4 }}
-          className="flex"
-        >
-          <button
-            onClick={handleStartGame}
-            disabled={!isReadyToStart(players)}
-            className={`flex-1 p-3 rounded-xl transition text-lg font-semibold ${
-              !isReadyToStart(players)
-                ? "bg-gray-500 cursor-not-allowed"
-                : "bg-green-500 hover:bg-green-600"
-            }`}
-          >
-            เริ่มเกม
-          </button>
-        </motion.div>
-      </main>
-
-      <footer className="mt-16 text-center text-sm text-gray-500">
-        <p>FNNz</p>
-      </footer>
-      <KawaiiMascot />
+          ))}
+        </div>
+      </div>
+      <Toast message={toast} show={!!toast} onClose={() => setToast("")} />
+      <BottomNav />
     </div>
   );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { motion } from "framer-motion";
 import BottomNav from "../components/BottomNav";
 
-export default function ResultPage() {
+function ResultContent() {
   const router = useRouter();
   const params = useSearchParams();
   const success = params.get("success") === "true";
@@ -32,5 +33,13 @@ export default function ResultPage() {
       </motion.div>
       <BottomNav />
     </div>
+  );
+}
+
+export default function ResultPage() {
+  return (
+    <Suspense fallback={null}>
+      <ResultContent />
+    </Suspense>
   );
 }

--- a/src/app/result/page.tsx
+++ b/src/app/result/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { motion } from "framer-motion";
+import BottomNav from "../components/BottomNav";
+
+export default function ResultPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const success = params.get("success") === "true";
+
+  return (
+    <div className="min-h-screen pb-16 flex flex-col items-center justify-center bg-gray-50 text-gray-800">
+      <motion.div
+        drag="y"
+        dragConstraints={{ top: 0, bottom: 0 }}
+        onDragEnd={(e, info) => {
+          if (info.offset.y > 50) router.push("/");
+        }}
+        className="bg-white rounded-xl shadow p-8 text-center w-full max-w-xs"
+      >
+        <h2 className="text-xl mb-2">
+          {success ? "Mission Success" : "Mission Failed"}
+        </h2>
+        <p className="mb-4">{success ? "+5 XP" : "+0 XP"}</p>
+        <button
+          onClick={() => router.push("/")}
+          className="w-full h-12 rounded-lg bg-pink-500 text-white"
+        >
+          Next
+        </button>
+      </motion.div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useState } from "react";
+import BottomNav from "../components/BottomNav";
+
+export default function SettingsPage() {
+  const [mute, setMute] = useState(false);
+  return (
+    <div className="min-h-screen pb-16 bg-gray-50 p-4 text-gray-800">
+      <h1 className="text-xl mb-4">Settings</h1>
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          className="h-4 w-4 accent-pink-500"
+          checked={mute}
+          onChange={() => setMute(!mute)}
+        />
+        <span>Mute</span>
+      </label>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/shop/page.tsx
+++ b/src/app/shop/page.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import BottomNav from "../components/BottomNav";
+
+const items = [
+  { name: "Pink Hat", price: "$1" },
+  { name: "Cool Shades", price: "$2" },
+  { name: "Spy Coat", price: "$3" },
+  { name: "Cute Boots", price: "$4" },
+  { name: "Secret Map", price: "$5" },
+  { name: "Bunny Ears", price: "$6" },
+];
+
+export default function ShopPage() {
+  return (
+    <div className="min-h-screen pb-16 bg-gray-50 p-4 text-gray-800">
+      <h1 className="text-xl mb-4">Shop</h1>
+      <div className="grid grid-cols-3 gap-4 text-center text-sm">
+        {items.map((item) => (
+          <div key={item.name} className="bg-white p-2 rounded-xl shadow">
+            <div className="h-12 bg-gray-50 rounded mb-2"></div>
+            <div>{item.name}</div>
+            <div className="text-pink-500">{item.price}</div>
+          </div>
+        ))}
+      </div>
+      <BottomNav />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce pink-accent minimalist theme and global styles
- add mission play loop with progress bar, toast feedback and bottom nav
- scaffold agents, inbox, shop, settings and onboarding screens

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Prompt`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6102193e48332b2191c5a6b080e00